### PR TITLE
set `Authorization` header and send JSON

### DIFF
--- a/autoload/deepl.vim
+++ b/autoload/deepl.vim
@@ -1,13 +1,14 @@
 " Send a translation request to deepl using curl
 function! deepl#translate(input, target_lang, source_lang = "")
   let cmd = "curl -sS " .. g:deepl#endpoint
-  let cmd = cmd .. ' -d "auth_key=' .. g:deepl#auth_key .. '"'
-  let cmd = cmd .. ' -d ' .. shellescape('text=' .. a:input)
-  let cmd = cmd .. ' -d "target_lang=' .. a:target_lang .. '"'
+  let json = { "text": [ a:input ], "target_lang": a:target_lang }
 
   if a:source_lang != ""
-    let cmd = cmd .. ' -d "source_lang=' .. a:source_lang .. '"'
+    let json['source_lang'] = a:source_lang
   endif
+
+  let cmd = cmd .. ' -H "Authorization: DeepL-Auth-Key ' .. g:deepl#auth_key .. '"'
+  let cmd = cmd .. ' --json ' .. shellescape(json_encode(json))
 
   try
     const res = json_decode(system(cmd))


### PR DESCRIPTION
Fixed query for curl command sent to API.

- Set authorization key in `Authorization` header and removed `auth_key=[key]`.
- Changed `--json` option to send application/json data.
