### PR TITLE
Update DeepL API request to match latest API changes

### DIFF
--- a/autoload/deepl.vim
+++ b/autoload/deepl.vim
@@ -1,13 +1,17 @@
 " Send a translation request to deepl using curl
 function! deepl#translate(input, target_lang, source_lang = "")
-  let cmd = "curl -sS " .. g:deepl#endpoint
-  let cmd = cmd .. ' -d "auth_key=' .. g:deepl#auth_key .. '"'
-  let cmd = cmd .. ' -d ' .. shellescape('text=' .. a:input)
-  let cmd = cmd .. ' -d "target_lang=' .. a:target_lang .. '"'
-
+  let data = #{
+        \ text: [a:input],
+        \ target_lang: a:target_lang,
+        \ }
   if a:source_lang != ""
-    let cmd = cmd .. ' -d "source_lang=' .. a:source_lang .. '"'
+    let data.source_lang = a:source_lang
   endif
+
+  let cmd = "curl -sS " .. g:deepl#endpoint
+  let cmd = cmd .. ' -H "Authorization: DeepL-Auth-Key ' .. g:deepl#auth_key .. '"'
+  let cmd = cmd .. ' -H "Content-Type: application/json"'
+  let cmd = cmd .. ' -d ' .. shellescape(json_encode(data))
 
   try
     const res = json_decode(system(cmd))


### PR DESCRIPTION
DeepL changed its API request requirements on 15th January, 2026.
https://developers.deepl.com/docs/resources/breaking-changes-change-notices/november-2025-deprecation-of-legacy-auth-methods

This PR updates the plugin to comply with the latest DeepL API specification.
https://developers.deepl.com/api-reference/translate

Thank you :)